### PR TITLE
Use HTTPS resources from CDNs

### DIFF
--- a/code/monthlyArchives/template.html
+++ b/code/monthlyArchives/template.html
@@ -3,12 +3,12 @@
 		<title>[%title%]</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<script src="http://fargo.io/code/jquery-1.9.1.min.js"></script>
-		<link href="http://fargo.io/code/bootstrap.css" rel="stylesheet">
-		<script src="http://fargo.io/code/bootstrap.min.js"></script>
-		<link href='http://fonts.googleapis.com/css?family=Oswald' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="http://fargo.io/code/fontAwesome/css/font-awesome.min.css"/>
-		<link href="http://fargo.io/code/ubuntuFont.css" rel="stylesheet" type="text/css">
+		<script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+		<link href='https://fonts.googleapis.com/css?family=Oswald' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
+		<link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet" type="text/css">
 		<link href="http://1999.io/testing/monthlyarchives/styles.css" rel="stylesheet" type="text/css">
 		<script>
 			function everySecond () {

--- a/code/templateedit.html
+++ b/code/templateedit.html
@@ -3,11 +3,11 @@
 		<title>Template Editor</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<script src="http://fargo.io/code/jquery-1.9.1.min.js"></script>
-		<link href="http://fargo.io/code/bootstrap.css" rel="stylesheet">
-		<script src="http://fargo.io/code/bootstrap.min.js"></script>
-		<link rel="stylesheet" href="http://fargo.io/code/fontAwesome/css/font-awesome.min.css"/>
-		<link href="http://fargo.io/code/ubuntuFont.css" rel="stylesheet" type="text/css">
+		<script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js""></script>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
+		<link href="https://fonts.googleapis.com/css?family=Ubuntu"" rel="stylesheet" type="text/css">
 		<script src="http://fargo.io/code/node/shared/utils.js"></script>
 		<script src="http://fargo.io/code/shared/ga.js"></script>
 		<script src="http://fargo.io/code/storage/api.js"></script>

--- a/code/websocketdemo.html
+++ b/code/websocketdemo.html
@@ -3,10 +3,10 @@
 		<title>1999.io client example</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<script src="http://fargo.io/code/jquery-1.9.1.min.js"></script>
-		<link href="http://fargo.io/code/ubuntuFont.css" rel="stylesheet" type="text/css">
-		<link href="http://fargo.io/code/bootstrap.css" rel="stylesheet">
-		<script src="http://fargo.io/code/bootstrap.min.js"></script>
+		<script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+		<link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet" type="text/css">
+		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 		
 		<script>
 			var myVersion = 0.46, myProductName = "1999client";


### PR DESCRIPTION
This is regarding #32 

I've changed the bootstrap css and js, the font-awesome css, the jquery js, and the Ubuntu and Oswald font css to alternatives on CDNs that serve content over `https`.

I haven't yet changed these

```
http://1999.io/testing/monthlyarchives/styles.css
http://fargo.io/code/node/shared/utils.js
http://fargo.io/code/shared/ga.js
http://fargo.io/code/storage/api.js
http://fargo.io/code/shared/xml.js
```

If I could be pointed to alternatives for these, I can add them in. Also, let me know if I've missed any other insecure resources.
